### PR TITLE
NEW: Remove --no-scripts from composer install

### DIFF
--- a/funcs.sh
+++ b/funcs.sh
@@ -9,10 +9,9 @@ function composer_install {
 	echo composer validate
     composer validate || true
 
-    echo composer install --no-progress --no-scripts --prefer-dist --no-dev --ignore-platform-reqs --optimize-autoloader --no-interaction --no-suggest
+    echo composer install --no-progress --prefer-dist --no-dev --ignore-platform-reqs --optimize-autoloader --no-interaction --no-suggest
     composer install \
         --no-progress \
-        --no-scripts \
         --prefer-dist \
         --no-dev \
         --ignore-platform-reqs \


### PR DESCRIPTION
Rationale:

 - The README also assumes that this is the case.
 - Exclusion of scripts was important when installs weren’t run in a
   safe environment, that’s no longer the case.
 - We already allow plugins, so arbitrary PHP can be executed, it’s 
   just a little more work. We make it harder for users, but don’t 
   protect from attacks.