### PR TITLE
NEW Use node:10 as base, add scp-build script invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,33 @@
-FROM composer:latest
+FROM node:10@sha256:2ac200a8175fbcdc3cda1b3ab384ba02b673ded7c06aa6bf9c41b9f9463d78c2
 
+RUN apt-get update && apt-get install -y curl php-cli git jq
+
+# Allow uninhibited SSH connections to support fetching external resources
 RUN mkdir -p ~/.ssh
 RUN chmod 0700 ~/.ssh
 RUN printf "Host *\nStrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n" > ~/.ssh/config
 RUN chmod 400 ~/.ssh/config
 
-RUN composer global require silverstripe/vendor-plugin-helper
+# Composer
+RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');"
+RUN php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
+
+# Fetch NVM installer and prep destination
+ENV NVM_DIR=/root/.nvm
+RUN mkdir -p /root/.nvm
+RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh > install.sh
+
+# Verify that the NVM installer remains uncompromised - bail on the build if not
+ENV NVM_EXPECTED_HASH="d41d8cd98f00b204e9800998ecf8427e  -"
+RUN if [ "`md5sum << install.sh`" != "$NVM_EXPECTED_HASH" ]; then exit 1; fi;
+
+# Install NVM without a default Node binary, add 6 + 8 + 10
+ENV NODE_VERSION=
+RUN bash install.sh
+RUN . $NVM_DIR/nvm.sh && nvm install v6 && nvm install v8 && nvm install v10
 
 COPY funcs.sh /funcs.sh
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+WORKDIR /app
 ENTRYPOINT ["/docker-entrypoint.sh"]
-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,4 +22,16 @@ fi
 
 composer_install
 
+# Run NPM/Yarn build script if the scp-build command is defined
+if [[ -f package.json && "`cat package.json | jq '.scripts["scp-build"]?'`" != "null" ]]; then
+    nvm_switch
+
+    node_build
+fi
+
+# Run Composer build script if the scp-build command is defined
+if [[ -f composer.json && "`cat composer.json | jq '.scripts["scp-build"]?'`" != "null" ]]; then
+	composer_build
+fi
+
 package_source ${SHA}

--- a/funcs.sh
+++ b/funcs.sh
@@ -1,5 +1,4 @@
 function composer_install {
-
 	if [ ! -f "composer.json" ]; then
 		echo "No composer.json present, skipping composer install."
 		return 0
@@ -19,6 +18,40 @@ function composer_install {
         --optimize-autoloader \
         --no-interaction \
         --no-suggest
+}
+
+function composer_build {
+	echo "Running: Composer Production Build Task"
+	composer run-script scp-build
+}
+
+function nvm_switch {
+	if [[ -f ".nvmrc" ]]; then
+		echo "Running: Apply NVM Configuration"
+		. /root/.nvm/nvm.sh --no-use
+		nvm use
+	else
+		echo "No .nvmrc found; Defaulting to Node 10"
+	fi
+}
+
+function node_build {
+	if [[ -f "yarn.lock" ]]; then
+		echo "Running: Yarn Dependency Installation"
+		yarn install --no-progress --non-interactive
+
+		echo "Running: Yarn Production Build Task"
+		yarn run scp-build
+	else
+		echo "Running: NPM Dependency Installation"
+		npm install
+
+		echo "Running: NPM Production Build Task"
+		npm run scp-build
+	fi
+
+	echo "Running: Purge Node Modules"
+	rm -rf node_modules/
 }
 
 function package_source {


### PR DESCRIPTION
This PR replaces [silverstripeltd/platform-build-yarn#2](https://github.com/silverstripeltd/platform-build-yarn/pull/2), and:

- Shifts the build image to be based on an up-to-date Node image
- Adds NVM with Node 6/8/10 to allow projects to target any Node LTS release
  - This includes checksum validation against the NVM installer during the Docker image creation
- Adds invocation of `scp-build` scripts if present in `package.json` or `composer.json` files