### PR TITLE
Move vendor-expose to end of process, fix indentation

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,34 +4,38 @@ set -e
 source /funcs.sh
 
 if [ -d ".git" ]; then
-    SHA=$(git rev-parse HEAD)
+	SHA=$(git rev-parse HEAD)
 else
-    echo "Unable to determine SHA, failing."
-    exit 1
+	echo "Unable to determine SHA, failing."
+	exit 1
 fi
 
 if [[ "z${IDENT_KEY}" == "z" ]]; then
-    echo "No deploy key set"
+	echo "No deploy key set"
 else
-    mkdir -p ~/.ssh
-    echo "${IDENT_KEY}" > ~/.ssh/id_rsa
-    chmod 0600 ~/.ssh/id_rsa
-    FINGER_PRINT=$(ssh-keygen -E md5 -lf ~/.ssh/id_rsa | awk '{ print $2 }' | cut -c 5-)
-    echo "Using deploy key ${FINGER_PRINT}"
+	mkdir -p ~/.ssh
+	echo "${IDENT_KEY}" > ~/.ssh/id_rsa
+	chmod 0600 ~/.ssh/id_rsa
+	FINGER_PRINT=$(ssh-keygen -E md5 -lf ~/.ssh/id_rsa | awk '{ print $2 }' | cut -c 5-)
+	echo "Using deploy key ${FINGER_PRINT}"
 fi
 
 composer_install
 
 # Run NPM/Yarn build script if the cloud-build command is defined
 if [[ -f package.json && "`cat package.json | jq '.scripts["cloud-build"]?'`" != "null" ]]; then
-    nvm_switch
+	nvm_switch
 
-    node_build
+	node_build
 fi
 
 # Run Composer build script if the cloud-build command is defined
 if [[ -f composer.json && "`cat composer.json | jq '.scripts["cloud-build"]?'`" != "null" ]]; then
 	composer_build
+fi
+
+if [[ -f vendor/silverstripe/vendor-plugin/composer.json ]]; then
+	composer_vendor_expose
 fi
 
 package_source ${SHA}


### PR DESCRIPTION
Since we use the `copy` mode to shift project and vendor resources into place, we should make sure this is done after the project's custom scripts have run so that their dist files are successfully copied. To minimise overhead, this means we want to disable the vendor-expose calls that happen automatically during `composer install`.

Unfortunately while implementing this, I discovered that versions of `silverstripe/vendor-plugin` (responsible for the vendor-expose behaviour) up to `1.4.0` break when you try to put them in 'no-op' mode. I released `1.4.1` today, but it'll take a while to propagate through `composer update`s, so any projects on earlier versions will see the vendor-expose operation run twice.