### PR TITLE
Refactor vendor-expose modification into function, fix version check

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,6 +20,11 @@ else
 	echo "Using deploy key ${FINGER_PRINT}"
 fi
 
+# Attempt to disable vendor-expose during composer install (CMS 4+)
+if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
+	disable_postinstall_vendor_expose
+fi
+
 composer_install
 
 # Run NPM/Yarn build script if the cloud-build command is defined
@@ -34,7 +39,8 @@ if [[ -f composer.json && "`cat composer.json | jq '.scripts["cloud-build"]?'`" 
 	composer_build
 fi
 
-if [[ -f vendor/silverstripe/vendor-plugin/composer.json ]]; then
+# Manually run vendor-expose once scripts have run (CMS 4+)
+if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
 	composer_vendor_expose
 fi
 


### PR DESCRIPTION
- Enabled the `-r` (raw) flag on the vendor-plugin version retrieval call to fix comparison
- Shifted the version check and resulting operations into a separate method
- Explicitly fall back to `copy` mode when vendor-plugin cannot be safely disabled to reinstate prior behaviour
- All vendor-plugin related checks now use `composer.lock` contents