### PR TITLE
Update base image to Debian Buster variant to move from PHP 7.0 -> 7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10@sha256:93e9a9283f0e2ead937a8f77a2c72b18f80005c10b57b4f1cfd40d2b3aa6595f
+FROM node:10-buster@sha256:c5a1bf0d035d9eea4d1cae7099bb5e1089bf8a439c25d0f19d010e909e9d7407
 
 RUN apt-get update && apt-get install -y curl php-cli git jq
 


### PR DESCRIPTION
The previous version of platform-build (1.0.2) used a distro with PHP 7.2 installed. The new `node@10` base image has PHP 7.0 installed, as it's based on Debian Stretch. We've seen at least one deployment failure caused by this older version, so this PR updates the base image to Debian Buster / PHP 7.3.