### PR TITLE
Set --no-scripts during Composer Install, add vendor-plugin-helper fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN chmod 400 ~/.ssh/config
 RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');"
 RUN php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
+# Install legacy vendor-plugin-helper module as a fallback for exposing assets
+RUN composer global require silverstripe/vendor-plugin-helper
+
 # Fetch NVM installer and prep destination
 ENV NVM_DIR=/root/.nvm
 RUN mkdir -p /root/.nvm

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,10 +20,10 @@ else
 	echo "Using deploy key ${FINGER_PRINT}"
 fi
 
-# Attempt to disable vendor-expose during composer install (CMS 4+)
-if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
-	disable_postinstall_vendor_expose
-fi
+# Attempt to disable vendor-expose during composer install (CMS 4+) - disabled until composer scripts are enabled again
+# if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
+# 	disable_postinstall_vendor_expose
+# fi
 
 composer_install
 


### PR DESCRIPTION
This will address potential issues with environments that depended on the vendor-plugin-helper fallback present in the 1.0.2 and earlier versions of platform-build, and reduce the risk of issues during `composer install` for other environments.

We can reintroduce script support during `composer install` behind a config flag later.