### PR TITLE
Add --frozen-lockfile flag to yarn install

### DIFF
--- a/funcs.sh
+++ b/funcs.sh
@@ -82,8 +82,8 @@ function set_node_version {
 
 function node_build {
 	if [[ -f "yarn.lock" ]]; then
-		echo "yarn install --no-progress --non-interactive"
-		yarn install --no-progress --non-interactive
+		echo "yarn install --no-progress --non-interactive --frozen-lockfile"
+		yarn install --no-progress --non-interactive --frozen-lockfile
 
 		echo "yarn run cloud-build"
 		yarn run cloud-build


### PR DESCRIPTION
This will prevent Silverstripe Cloud from potentially updating npm dependencies to versions that aren't specified in the yarn.lock file

Docs on this are pretty light https://classic.yarnpkg.com/en/docs/cli/install/ but this Github comment here sums it up pretty well https://github.com/yarnpkg/yarn/issues/5847#issuecomment-537521943
