### PR TITLE
CCL-4 Update platform builder 1.3 branch to use non-root user to build CMS projects 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,12 @@ RUN . $NVM_DIR/nvm.sh && nvm install v6 && nvm install v8 && nvm install v10 && 
 
 COPY --chown=build:build funcs.sh /home/build/funcs.sh
 COPY --chown=build:build parse_composer.php /home/build/parse_composer.php
-COPY --chown=build:build docker-entrypoint.sh /home/build/docker-entrypoint.sh
+COPY --chown=build:build build-project.sh /home/build/build-project.sh
+
+COPY --chmod=500 docker-entrypoint.sh /docker-entrypoint.sh
 
 WORKDIR /app
 
-ENTRYPOINT ["/home/build/docker-entrypoint.sh"]
+USER root
+
+ENTRYPOINT ["/docker-entrypoint.sh", "build"]

--- a/build-project.sh
+++ b/build-project.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copy the project to another directory so that the non-root user can work with it.
+cd ~/
+mkdir -p site
+cp -rp "${APP_DIR}"/. site
+cd site/
+
+# Now build it.
+source ~/funcs.sh
+
+if [ -d ".git" ]; then
+	SHA=$(git rev-parse HEAD)
+else
+	echo "Unable to determine SHA, failing."	
+	exit 1
+fi
+
+if [[ "z${IDENT_KEY}" == "z" ]]; then
+	echo "No deploy key set"
+else
+	mkdir -p ~/.ssh
+	echo "${IDENT_KEY}" > ~/.ssh/id_rsa
+	chmod 0600 ~/.ssh/id_rsa
+	FINGER_PRINT=$(ssh-keygen -E md5 -lf ~/.ssh/id_rsa | awk '{ print $2 }' | cut -c 5-)
+	echo "Using deploy key ${FINGER_PRINT}"
+fi
+
+# Docs mention the cache is at /tmp/cache. Make sure this is true!
+export COMPOSER_HOME="/tmp"
+
+# Provide simple fingerprint for detecting that a deployment is in progress
+export CLOUD_BUILD=1
+
+if [ "${PARSE_COMPOSER}" != "" ]; then
+	echo "Running parse_composer..."
+	parse_composer
+fi
+
+# Disable vendor-expose during composer install (CMS 4+)
+if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
+	disable_postinstall_vendor_expose
+fi
+
+composer_install
+
+if [ "${CLOUD_BUILD_DISABLED}" == "" ]; then
+	echo "Running cloud-build..."
+
+	# Run NPM/Yarn build script if the cloud-build command is defined
+	if [[ -f package.json && "$(cat package.json | jq '.scripts["cloud-build"]?')" != "null" ]]; then
+		set_node_version
+
+		node_build
+	fi
+
+	# Run Composer build script if the cloud-build command is defined
+	if [[ -f composer.json && "$(cat composer.json | jq '.scripts["cloud-build"]?')" != "null" ]]; then
+		composer_build
+	fi
+
+fi
+
+# Manually run vendor-expose once scripts have run (CMS 4+)
+if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
+	composer_vendor_expose
+fi
+
+package_source ${SHA}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,12 +11,14 @@ fi
 USER_ID=$(id -u "$USER")
 USER_GID=$(id -g "$USER")
 
-# Cache directory is mounted with root as owner so need to make it writeable by the non-root user. 
+# Cache directory is mounted with root as owner so need to make it writeable by the non-root user.
 chown -R $USER_ID:$USER_GID /tmp/cache
 
-# SSH key is mounted in root ssh directory, but we need it in the non-root user's home directory. 
-cp ~/.ssh/id_rsa /home/"$USER"/.ssh/
-chown "$USER_ID":"$USER_GID" /home/"$USER"/.ssh/id_rsa
+# If SSH key is mounted in root ssh directory, we'll need it in the non-root user's home directory.
+if [ -f ~/.ssh/id_rsa ]; then
+    cp ~/.ssh/id_rsa /home/"$USER"/.ssh/
+    chown "$USER_ID":"$USER_GID" /home/"$USER"/.ssh/id_rsa
+fi
 
 export APP_DIR="/${PWD##*/}"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-source /funcs.sh
+source ~/funcs.sh
+
+WORKING_DIR="/${PWD##*/}"
+cd ~/
+mkdir -p site
+cp -rp "${WORKING_DIR}"/. site
+cd site/
 
 if [ -d ".git" ]; then
 	SHA=$(git rev-parse HEAD)
@@ -61,3 +67,5 @@ if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name 
 fi
 
 package_source ${SHA}
+
+/bin/bash

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,71 +1,30 @@
 #!/usr/bin/env bash
 set -e
 
-source ~/funcs.sh
+USER="$1"
 
-WORKING_DIR="/${PWD##*/}"
-cd ~/
-mkdir -p site
-cp -rp "${WORKING_DIR}"/. site
-cd site/
-
-if [ -d ".git" ]; then
-	SHA=$(git rev-parse HEAD)
-else
-	echo "Unable to determine SHA, failing."
-	exit 1
+if [ -z "$USER" ] ; then
+    echo "Invalid build user given, failing."
+    exit 1
 fi
 
-if [[ "z${IDENT_KEY}" == "z" ]]; then
-	echo "No deploy key set"
-else
-	mkdir -p ~/.ssh
-	echo "${IDENT_KEY}" > ~/.ssh/id_rsa
-	chmod 0600 ~/.ssh/id_rsa
-	FINGER_PRINT=$(ssh-keygen -E md5 -lf ~/.ssh/id_rsa | awk '{ print $2 }' | cut -c 5-)
-	echo "Using deploy key ${FINGER_PRINT}"
-fi
+USER_ID=$(id -u "$USER")
+USER_GID=$(id -g "$USER")
 
-# Docs mention the cache is at /tmp/cache. Make sure this is true!
-export COMPOSER_HOME="/tmp"
+# Cache directory is mounted with root as owner so need to make it writeable by the non-root user. 
+chown -R $USER_ID:$USER_GID /tmp/cache
 
-# Provide simple fingerprint for detecting that a deployment is in progress
-export CLOUD_BUILD=1
+# SSH key is mounted in root ssh directory, but we need it in the non-root user's home directory. 
+cp ~/.ssh/id_rsa /home/"$USER"/.ssh/
+chown "$USER_ID":"$USER_GID" /home/"$USER"/.ssh/id_rsa
 
-if [ "${PARSE_COMPOSER}" != "" ]; then
-	echo "Running parse_composer..."
-	parse_composer
-fi
+export APP_DIR="/${PWD##*/}"
 
-# Disable vendor-expose during composer install (CMS 4+)
-if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
-	disable_postinstall_vendor_expose
-fi
+# Run as non-root user and make required environment variables available to the script.
+su --command="/bin/bash /home/$USER/build-project.sh" \
+    --shell=/bin/bash \
+    --whitelist-environment="CLOUD_BUILD_DISABLED,PARSE_COMPOSER,IDENT_KEY,APP_DIR" \
+    - "${USER}"
 
-composer_install
-
-if [ "${CLOUD_BUILD_DISABLED}" == "" ]; then
-	echo "Running cloud-build..."
-
-	# Run NPM/Yarn build script if the cloud-build command is defined
-	if [[ -f package.json && "`cat package.json | jq '.scripts["cloud-build"]?'`" != "null" ]]; then
-		set_node_version
-
-		node_build
-	fi
-
-	# Run Composer build script if the cloud-build command is defined
-	if [[ -f composer.json && "`cat composer.json | jq '.scripts["cloud-build"]?'`" != "null" ]]; then
-		composer_build
-	fi
-
-fi
-
-# Manually run vendor-expose once scripts have run (CMS 4+)
-if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
-	composer_vendor_expose
-fi
-
-package_source ${SHA}
-
-/bin/bash
+# Move artefact to the location dash expects it to be.
+mv /home/"$USER"/payload-source* /

--- a/funcs.sh
+++ b/funcs.sh
@@ -67,7 +67,7 @@ function composer_vendor_expose {
 
 	if [ "$RETVAL" -gt "0" ]; then
 		echo "[WARNING] 'composer vendor-expose' failed. Falling back to vendor-plugin-helper. Please address this failure, as this fallback will be removed in a future update." >&2
-		/root/.composer/vendor/bin/vendor-plugin-helper copy ./
+		~/.composer/vendor/bin/vendor-plugin-helper copy ./
 	fi
 }
 
@@ -77,7 +77,7 @@ function composer_build {
 }
 
 function set_node_version {
-	. /root/.nvm/nvm.sh --no-use
+	. ~/.nvm/nvm.sh --no-use
 
 	if [[ -f ".nvmrc" ]]; then
 		echo "nvm use"
@@ -109,10 +109,7 @@ function node_build {
 
 function package_source {
 	echo "Packaging up source code"
-	# WORKING_DIR="/${PWD##*/}"
 	cd ~/
-	# mkdir -p site
-	# cp -rp ${WORKING_DIR}/. site
 	rm -rf site/.git/
 	tar -czf payload-source-"$1".tgz site
 	du -h payload-source-"$1".tgz

--- a/funcs.sh
+++ b/funcs.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # We want to disable vendor-expose calls during composer install, as we run
 # this manually later, but earlier releases of silverstripe/vendor-plugin
 # have a broken 'none' mode implementation, so we fall back to 'copy' mode.
@@ -30,7 +32,7 @@ function disable_postinstall_vendor_expose {
 # Copied from CWP, some sites still use the bespoke "private": "true" flag which redirects URLs to internal SSH.
 function parse_composer {
 	cp composer.lock composer.lock.orig
-	/usr/local/bin/php /parse_composer.php composer.json composer.lock.orig > composer.lock
+	/usr/local/bin/php /home/build/parse_composer.php composer.json composer.lock.orig > composer.lock
 }
 
 # TODO: Allow scripts during composer install if explicit configuration is present
@@ -107,11 +109,11 @@ function node_build {
 
 function package_source {
 	echo "Packaging up source code"
-	WORKING_DIR=${PWD##*/}
-	cd ../
-	mkdir -p site
-	cp -rp ${WORKING_DIR}/. site
+	# WORKING_DIR="/${PWD##*/}"
+	cd ~/
+	# mkdir -p site
+	# cp -rp ${WORKING_DIR}/. site
 	rm -rf site/.git/
-	tar -czf /payload-source-"$1".tgz site
-	du -h /payload-source-"$1".tgz
+	tar -czf payload-source-"$1".tgz site
+	du -h payload-source-"$1".tgz
 }

--- a/funcs.sh
+++ b/funcs.sh
@@ -32,7 +32,7 @@ function disable_postinstall_vendor_expose {
 # Copied from CWP, some sites still use the bespoke "private": "true" flag which redirects URLs to internal SSH.
 function parse_composer {
 	cp composer.lock composer.lock.orig
-	/usr/local/bin/php /home/build/parse_composer.php composer.json composer.lock.orig > composer.lock
+	/usr/local/bin/php ~/parse_composer.php composer.json composer.lock.orig > composer.lock
 }
 
 # TODO: Allow scripts during composer install if explicit configuration is present


### PR DESCRIPTION
https://silverstripe.atlassian.net/browse/CCL-4

The `docker-entrypoint.sh` now executes other scripts as a non-root user (build) using `su` to build the project code. These changes are compatible with the current dash code ie the code builder on an environment can be switched between this and other versions as required without any changes to dash code. 

Will update version 2.0.x line in another PR. 

**Deployment testing scenarios**
* The docker image with the changes to dockerhub for testing (rbarling/platform-build:1.3.2-dev) and added as option on test cluster dash. 
* When deploying a different CMS version, the database was dropped and an empty one recreated so that the test on a new CMS version started on with a blank slate. 
* no dash code changes were deployed. 
* On each deployment, the _Force rebuild of codebase_ option was ticked.

1. Base test - CMS 5.1.8 and code builder 1.3.2
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3908

3. CMS 5.1.8 and code builder 1.3.2-dev - successful 
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3911

4. CMS 5.1.8 and revert to code builder 1.3.2  - successful
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3914

5. cms 4.13.44 with code builder 1.3.2-dev - successful
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3917

6. cms 4.13.44 with code builder 1.3.2 - successful
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3923

Note: The CMS 5.1.8 had issues with the stylesheets that was present when deployed with both code builder 1.3.2 and 1.3.2-dev so this is not related to the platform-build changes in this PR. 

**Dev testing locally**
To mimic CCL, you can run the command below which adds extra environment variables when the container is started. 
```
docker run --interactive --tty --volume composer_cache:/tmp/cache --volume ~/.ssh/id_rsa:/root/.ssh/id_rsa:ro --volume $PWD:/app --cidfile '/tmp/docker.cid' --env PARSE_COMPOSER=1 --env CLOUD_BUILD_DISABLED=1 rbarling/platform-build:1.3.2-dev
```
You can then use the `docker.cid` file to extract the artefact. 
```
docker cp $(cat /tmp/docker.cid):/payload-source-<hash>.tgz /destination/path
```
