### PR TITLE
CC4 - Update platform builder 2.0 branch to use non-root user to build CMS projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,16 @@ RUN pecl install zip && docker-php-ext-enable zip
 # Pull Composer from base image
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
+# Adding a non-root user to execute scripts in the container
+RUN useradd -d /home/build -s /usr/sbin/nologin -m -u 2000 -U build
+
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install -y --no-install-recommends yarn
+
+USER build
+
 # Allow uninhibited SSH connections to support fetching external resources
 RUN mkdir -p ~/.ssh
 RUN chmod 0700 ~/.ssh
@@ -19,9 +29,11 @@ RUN chmod 400 ~/.ssh/config
 # Install legacy vendor-plugin-helper module as a fallback for exposing assets
 RUN composer global require silverstripe/vendor-plugin-helper
 
+WORKDIR /home/build
+
 # Fetch NVM installer and prep destination
-ENV NVM_DIR=/root/.nvm
-RUN mkdir -p /root/.nvm
+ENV NVM_DIR=/home/build/.nvm
+RUN mkdir -p ~/.nvm
 RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh > install.sh
 
 # Verify that the NVM installer remains uncompromised - bail on the build if not
@@ -33,13 +45,13 @@ ENV NODE_VERSION=
 RUN bash install.sh
 RUN . $NVM_DIR/nvm.sh && nvm install v6 && nvm install v8 && nvm install v10 && nvm install v12 && nvm install v14 && nvm install v16
 
-# Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y --no-install-recommends yarn
+COPY --chown=build:build funcs.sh /home/build/funcs.sh
+COPY --chown=build:build build-project.sh /home/build/build-project.sh
 
-COPY funcs.sh /funcs.sh
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY --chmod=500 docker-entrypoint.sh /docker-entrypoint.sh
 
 WORKDIR /app
-ENTRYPOINT ["/docker-entrypoint.sh"]
+
+USER root
+
+ENTRYPOINT ["/docker-entrypoint.sh", "build"]

--- a/build-project.sh
+++ b/build-project.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copy the project to another directory so that the non-root user can work with it.
+cd ~/
+mkdir -p site
+cp -rp "${APP_DIR}"/. site
+cd site/
+
+# Now build it.
+source ~/funcs.sh
+
+if [ -d ".git" ]; then
+	SHA=$(git rev-parse HEAD)
+else
+	echo "Unable to determine SHA, failing."	
+	exit 1
+fi
+
+if [[ "z${IDENT_KEY}" == "z" ]]; then
+	echo "No deploy key set"
+else
+	mkdir -p ~/.ssh
+	echo "${IDENT_KEY}" > ~/.ssh/id_rsa
+	chmod 0600 ~/.ssh/id_rsa
+	FINGER_PRINT=$(ssh-keygen -E md5 -lf ~/.ssh/id_rsa | awk '{ print $2 }' | cut -c 5-)
+	echo "Using deploy key ${FINGER_PRINT}"
+fi
+
+# Docs mention the cache is at /tmp/cache. Make sure this is true!
+export COMPOSER_HOME="/tmp"
+
+# Provide simple fingerprint for detecting that a deployment is in progress
+export CLOUD_BUILD=1
+
+# Disable vendor-expose during composer install (CMS 4+)
+if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
+	disable_postinstall_vendor_expose
+fi
+
+composer_install
+
+if [ "${CLOUD_BUILD_DISABLED}" == "" ]; then
+	echo "Running cloud-build..."
+
+	# Run NPM/Yarn build script if the cloud-build command is defined
+	if [[ -f package.json && "$(cat package.json | jq '.scripts["cloud-build"]?')" != "null" ]]; then
+		set_node_version
+
+		node_build
+	fi
+
+	# Run Composer build script if the cloud-build command is defined
+	if [[ -f composer.json && "$(cat composer.json | jq '.scripts["cloud-build"]?')" != "null" ]]; then
+		composer_build
+	fi
+
+fi
+
+# Manually run vendor-expose once scripts have run (CMS 4+)
+if [[ -f composer.lock && "$(cat composer.lock | jq '.packages[] | select(.name == "silverstripe/vendor-plugin")')" != "" ]]; then
+	composer_vendor_expose
+fi
+
+package_source ${SHA}

--- a/funcs.sh
+++ b/funcs.sh
@@ -59,7 +59,7 @@ function composer_vendor_expose {
 
 	if [ "$RETVAL" -gt "0" ]; then
 		echo "[WARNING] 'composer vendor-expose' failed. Falling back to vendor-plugin-helper. Please address this failure, as this fallback will be removed in a future update." >&2
-		/root/.composer/vendor/bin/vendor-plugin-helper copy ./
+		~/.composer/vendor/bin/vendor-plugin-helper copy ./
 	fi
 }
 
@@ -69,7 +69,7 @@ function composer_build {
 }
 
 function set_node_version {
-	. /root/.nvm/nvm.sh --no-use
+	. ~/.nvm/nvm.sh --no-use
 
 	if [[ -f ".nvmrc" ]]; then
 		echo "nvm use"
@@ -101,11 +101,8 @@ function node_build {
 
 function package_source {
 	echo "Packaging up source code"
-	WORKING_DIR=${PWD##*/}
-	cd ../
-	mkdir -p site
-	cp -rp ${WORKING_DIR}/. site
+	cd ~/
 	rm -rf site/.git/
-	tar -czf /payload-source-"$1".tgz site
-	du -h /payload-source-"$1".tgz
+	tar -czf payload-source-"$1".tgz site
+	du -h payload-source-"$1".tgz
 }


### PR DESCRIPTION
https://silverstripe.atlassian.net/browse/CCL-4

Note: This PR contains the same work as https://github.com/silverstripeltd/platform-build/pull/25 but on the v2.0 line. 

The docker-entrypoint.sh now executes other scripts as a non-root user (build) using su to build the project code. These changes are compatible with the current dash code ie the code builder on an environment can be switched between this and other versions as required without any changes to dash code.

### Deployment testing scenarios

- The docker image with the changes to dockerhub for testing (**rbarling/platform-build:2.0.1-dev**) and added as option on test cluster dash.
- When deploying a different CMS version, the database was dropped and an empty one recreated so that the test on a new CMS version started on with a blank slate.
- no dash code changes were deployed.
- On each deployment, the Force rebuild of codebase option was ticked.
- PHP version was set to 8.1 before deploying CMS 5 code.
- Smoke test was done by navigating to the site and logging into the CMS backend after every deployment. 

1. CMS 4.13 - successful
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3956

2. CMS 3.7.5 - successful 
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3965

3. CMS 5.1.23 - successful
https://cwpwgtn.silverstripe.cloud/naut/project/bustertest/environment/test1/overview/deployment/3977

**Dev testing locally**
To mimic CCL, you can run the command below which adds extra environment variables when the container is started. 
```
docker run --interactive --tty --volume composer_cache:/tmp/cache --volume ~/.ssh/id_rsa:/root/.ssh/id_rsa:ro --volume $PWD:/app --cidfile '/tmp/docker.cid' --env PARSE_COMPOSER=1 --env CLOUD_BUILD_DISABLED=1 rbarling/platform-build:1.3.2-dev
```
You can then use the `docker.cid` file to extract the artefact. 
```
docker cp $(cat /tmp/docker.cid):/payload-source-<hash>.tgz /destination/path
```