### PR TITLE
Fix immediate script termination on error v1.3 line

### DIFF
--- a/build-project.sh
+++ b/build-project.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Copy the project to another directory so that the non-root user can work with it.
 cd ~/


### PR DESCRIPTION
Any command execution failure in `build-project.sh` (non-zero exit status) should immediately terminate the parent script and end the docker run. 