### PR TITLE
Remove pre-installed node versions and install from .nvmrc file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,9 @@ RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh > insta
 ENV NVM_EXPECTED_HASH="586d621487c98d7ae0b6f9727ec5bd84  install.sh"
 RUN if [ "`md5sum install.sh`" != "$NVM_EXPECTED_HASH" ]; then exit 1; fi;
 
-# Install NVM without a default Node binary, add all LTS versions
-ENV NODE_VERSION=
+# Install NVM with a default Node binary of 16
+ENV NODE_VERSION=16
 RUN bash install.sh
-RUN . $NVM_DIR/nvm.sh && nvm install v16 && nvm install v18 && nvm install v20
 
 # Install Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [ "${CLOUD_BUILD_DISABLED}" == "" ]; then
 
 	# Run NPM/Yarn build script if the cloud-build command is defined
 	if [[ -f package.json && "`cat package.json | jq '.scripts["cloud-build"]?'`" != "null" ]]; then
-		set_node_version
+		node_install
 
 		node_build
 	fi

--- a/funcs.sh
+++ b/funcs.sh
@@ -68,12 +68,12 @@ function composer_build {
 	composer run-script cloud-build
 }
 
-function set_node_version {
+function node_install {
 	. /root/.nvm/nvm.sh --no-use
 
 	if [[ -f ".nvmrc" ]]; then
-		echo "nvm use"
-		nvm use
+		echo "nvm install"
+		nvm install
 	else
 		echo "No .nvmrc found; Defaulting to Node 16"
 		nvm use 16


### PR DESCRIPTION
Cloudbuild currently pre-installs versions of NodeJS which can be used by developers, however this is restrictive and doesn't support upgrading / usage of alternative version very well.

These changes will install the version defined by `.nvmrc` instead allowing developers to define what version of Node they would like to use, otherwise it will default to NodeJS 16 .

Example of have `.nvmrc` with `22` defined.
```
Running cloud-build...
nvm install
Found '/app/.nvmrc' with version <22>
Downloading and installing node v22.14.0...
Downloading https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz...
#################################################################################################################################################################### 100.0%
Computing checksum with sha256sum
Checksums matched!
Now using node v22.14.0 (npm v10.9.2)
```