### PR TITLE
SCP-552 Force usage of globally installed yarn

### DIFF
--- a/funcs.sh
+++ b/funcs.sh
@@ -83,10 +83,10 @@ function node_install {
 function node_build {
 	if [[ -f "yarn.lock" ]]; then
 		echo "yarn install --no-progress --non-interactive"
-		yarn install --no-progress --non-interactive
+		YARN_IGNORE_PATH=1 yarn install --no-progress --non-interactive
 
 		echo "yarn run cloud-build"
-		yarn run cloud-build
+		YARN_IGNORE_PATH=1 yarn run cloud-build
 	else
 		echo "npm install"
 		npm install


### PR DESCRIPTION
As per title, there is a possibility that projects may include yarn binaries and configuration to use it instead of the global one installed by platform build. This change will ignore that configuration and force the usage of the global yarn instead for security reasons. 