### PR TITLE
Update composer to v2.9.7 for codebuilder 2.1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Core tools / PHP extensions
-FROM composer:2@sha256:6b8dbded0cfb109dd3b06902ba4b0406d9eda689ccce5363c46f8bf25451b083 AS composer
+FROM composer:2@sha256:b148074c5cf8e5c564e92baa3f0d2e28ffa0361ede57a03de3bf4b9cf80de54a AS composer
 FROM php:8.2-cli@sha256:5d2d115e42afd2ac0c8373758221a6e942bac1d0f50d4928db6c6663d4d25981
 
 # Install core dependencies
@@ -17,6 +17,8 @@ RUN printf "Host *\nStrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n" > 
 RUN chmod 400 ~/.ssh/config
 
 # Install legacy vendor-plugin-helper module as a fallback for exposing assets
+RUN composer global config audit.block-insecure false
+RUN composer global config --no-plugins allow-plugins true
 RUN composer global require silverstripe/vendor-plugin-helper
 
 # Fetch NVM installer and prep destination

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN printf "Host *\nStrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n" > 
 RUN chmod 400 ~/.ssh/config
 
 # Install legacy vendor-plugin-helper module as a fallback for exposing assets
-RUN composer global config audit.block-insecure false
-RUN composer global config --no-plugins allow-plugins true
-RUN composer global require silverstripe/vendor-plugin-helper
+RUN composer global config allow-plugins.composer/installers true
+RUN composer global config allow-plugins.silverstripe/vendor-plugin true
+RUN composer global require silverstripe/vendor-plugin-helper --no-security-blocking
 
 # Fetch NVM installer and prep destination
 ENV NVM_DIR=/root/.nvm


### PR DESCRIPTION
https://silverstripe.atlassian.net/browse/SCP-718

Upgrading composer to remedy the recent composer vulnerability. Also configure composer to resolve the error below and allow the install of the `silverstripe/vendor-plugin-helper` using this composer version. 

```
3.392   Problem 1
3.392     - Root composer.json requires silverstripe/vendor-plugin-helper * -> satisfiable by silverstripe/vendor-plugin-helper[1.0.0].
3.392     - silverstripe/vendor-plugin-helper 1.0.0 requires composer/composer ^1.5 -> found composer/composer[1.5.0, ..., 1.10.27] but these were not loaded, because they are affected by security advisories ("PKSA-t5r2-p5q9-mtpn", "PKSA-6bp1-9hfj-2cgv", "PKSA-m1ph-vmbx-2xd3", "PKSA-6zmq-d6mk-r5wm", "PKSA-93hy-9dc1-gbwt", "PKSA-9p8h-97x3-qxpm"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
3.392
3.394 You can also try re-running composer require with an explicit version constraint, e.g. "composer require silverstripe/vendor-plugin-helper:*" to figure out if any version is installable, or "composer require silverstripe/vendor-plugin-helper:^2.1" if you know which you need
```

